### PR TITLE
Return spec-compliant JSON-RPC error response on panic in WithSentry middleware

### DIFF
--- a/sentry.go
+++ b/sentry.go
@@ -17,7 +17,7 @@ import (
 // version, method. It's also handles panic.
 func WithSentry(serverName string) zenrpc.MiddlewareFunc {
 	return func(h zenrpc.InvokeFunc) zenrpc.InvokeFunc {
-		return func(ctx context.Context, method string, params json.RawMessage) zenrpc.Response {
+		return func(ctx context.Context, method string, params json.RawMessage) (response zenrpc.Response) {
 			defer func() {
 				var err error
 				var rec any
@@ -28,6 +28,8 @@ func WithSentry(serverName string) zenrpc.MiddlewareFunc {
 					default:
 						err = fmt.Errorf("%v", e)
 					}
+
+					response = zenrpc.NewResponseError(nil, zenrpc.InternalError, "", nil)
 				}
 
 				if hub := sentry.GetHubFromContext(ctx); hub != nil {


### PR DESCRIPTION
### Problem                                                                                                                                                                              
When a panic occurs inside an RPC handler wrapped by `WithSentry`, the `defer/recover` block catches the panic and reports it to Sentry, but the response returned to the client is an empty `zenrpc.Response` zero-value:                                                                                                                             

```                                                                                                                                                                      
{
   "jsonrpc": "", 
    "id": 1
} 
```               
This violates the https://www.jsonrpc.org/specification,                                                              
  - "jsonrpc" field to always be "2.0"                                                                                                                                          
  - An "error" object to be present when the call fails                                                                                                                         

### Fix                                                                                                                                                                           

Two minimal changes in WithSentry:                                                                                                                                            
                                                                                                                                                                                
  1. Named return value - changed the anonymous return zenrpc.Response to a named return (resp zenrpc.Response) so that the deferred recovery function can assign a proper response.                                                                                                                                      
  2. Set error response on panic - added resp = zenrpc.NewResponseError(nil, zenrpc.InternalError, "", nil) inside the recover block, which produces a spec-compliant error response:                                                                              

```
{
    "jsonrpc": "2.0", 
    "id": 1, 
    "error": 
    {
        "code": -32603, 
        "message": "Internal error"
    }
}
```                                                                                                                                                                                                                                                                  
Error code -32603 (InternalError) is the appropriate code defined by the JSON-RPC 2.0 spec for internal server errors.                                                                                                                                                                                                                                      